### PR TITLE
Fix for issues in importing the tap

### DIFF
--- a/Formula/sdkmancli.rb
+++ b/Formula/sdkmancli.rb
@@ -1,4 +1,4 @@
-class SdkmanCli < Formula
+class Sdkmancli < Formula
   desc "Sdkman - The Software Development Kit Manager"
   homepage "https://sdkman.io"
   url "https://github.com/sdkman/sdkman-cli/releases/download/5.18.2/sdkman-cli-5.18.2.zip"


### PR DESCRIPTION
Unless applying this fix for https://github.com/sdkman/homebrew-tap/issues/5, now the tap cannot even be imported..

It looks like Brew has become more strict in checking syntax errors in (imported) formulas, as the following are errors I get when trying to (unsuccessfully) tap this repo (after having untapped it):

$ brew tap sdkman/tap
==> Tapping sdkman/tap
Cloning into '/opt/homebrew/Library/Taps/sdkman/homebrew-tap'...
remote: Enumerating objects: 55, done.
remote: Counting objects: 100% (55/55), done.
remote: Compressing objects: 100% (47/47), done.
remote: Total 55 (delta 16), reused 39 (delta 0), pack-reused 0
Receiving objects: 100% (55/55), 10.36 KiB | 3.45 MiB/s, done.
Resolving deltas: 100% (16/16), done.
Error: Invalid formula (sonoma): /opt/homebrew/Library/Taps/sdkman/homebrew-tap/Formula/sdkmancli.rb
No available formula with the name "sdkmancli". Did you mean sdkman-cli?
In formula file: /opt/homebrew/Library/Taps/sdkman/homebrew-tap/Formula/sdkmancli.rb
Expected to find class Sdkmancli, but only found: SdkmanCli.
Error: Invalid formula (arm64_sonoma): /opt/homebrew/Library/Taps/sdkman/homebrew-tap/Formula/sdkmancli.rb
No available formula with the name "sdkmancli". Did you mean sdkman-cli?
In formula file: /opt/homebrew/Library/Taps/sdkman/homebrew-tap/Formula/sdkmancli.rb
Expected to find class Sdkmancli, but only found: SdkmanCli.
Error: Invalid formula (ventura): /opt/homebrew/Library/Taps/sdkman/homebrew-tap/Formula/sdkmancli.rb
No available formula with the name "sdkmancli". Did you mean sdkman-cli?
In formula file: /opt/homebrew/Library/Taps/sdkman/homebrew-tap/Formula/sdkmancli.rb
Expected to find class Sdkmancli, but only found: SdkmanCli.
Error: Invalid formula (arm64_ventura): /opt/homebrew/Library/Taps/sdkman/homebrew-tap/Formula/sdkmancli.rb
No available formula with the name "sdkmancli". Did you mean sdkman-cli?
In formula file: /opt/homebrew/Library/Taps/sdkman/homebrew-tap/Formula/sdkmancli.rb
Expected to find class Sdkmancli, but only found: SdkmanCli.
Error: Invalid formula (monterey): /opt/homebrew/Library/Taps/sdkman/homebrew-tap/Formula/sdkmancli.rb
No available formula with the name "sdkmancli". Did you mean sdkman-cli?
In formula file: /opt/homebrew/Library/Taps/sdkman/homebrew-tap/Formula/sdkmancli.rb
Expected to find class Sdkmancli, but only found: SdkmanCli.
Error: Invalid formula (arm64_monterey): /opt/homebrew/Library/Taps/sdkman/homebrew-tap/Formula/sdkmancli.rb
No available formula with the name "sdkmancli". Did you mean sdkman-cli?
In formula file: /opt/homebrew/Library/Taps/sdkman/homebrew-tap/Formula/sdkmancli.rb
Expected to find class Sdkmancli, but only found: SdkmanCli.
Error: Invalid formula (big_sur): /opt/homebrew/Library/Taps/sdkman/homebrew-tap/Formula/sdkmancli.rb
No available formula with the name "sdkmancli". Did you mean sdkman-cli?
In formula file: /opt/homebrew/Library/Taps/sdkman/homebrew-tap/Formula/sdkmancli.rb
Expected to find class Sdkmancli, but only found: SdkmanCli.
Error: Invalid formula (arm64_big_sur): /opt/homebrew/Library/Taps/sdkman/homebrew-tap/Formula/sdkmancli.rb
No available formula with the name "sdkmancli". Did you mean sdkman-cli?
In formula file: /opt/homebrew/Library/Taps/sdkman/homebrew-tap/Formula/sdkmancli.rb
Expected to find class Sdkmancli, but only found: SdkmanCli.
Error: Invalid formula (catalina): /opt/homebrew/Library/Taps/sdkman/homebrew-tap/Formula/sdkmancli.rb
No available formula with the name "sdkmancli". Did you mean sdkman-cli?
In formula file: /opt/homebrew/Library/Taps/sdkman/homebrew-tap/Formula/sdkmancli.rb
Expected to find class Sdkmancli, but only found: SdkmanCli.
Error: Invalid formula (mojave): /opt/homebrew/Library/Taps/sdkman/homebrew-tap/Formula/sdkmancli.rb
No available formula with the name "sdkmancli". Did you mean sdkman-cli?
In formula file: /opt/homebrew/Library/Taps/sdkman/homebrew-tap/Formula/sdkmancli.rb
Expected to find class Sdkmancli, but only found: SdkmanCli.
Error: Invalid formula (high_sierra): /opt/homebrew/Library/Taps/sdkman/homebrew-tap/Formula/sdkmancli.rb
No available formula with the name "sdkmancli". Did you mean sdkman-cli?
In formula file: /opt/homebrew/Library/Taps/sdkman/homebrew-tap/Formula/sdkmancli.rb
Expected to find class Sdkmancli, but only found: SdkmanCli.
Error: Invalid formula (sierra): /opt/homebrew/Library/Taps/sdkman/homebrew-tap/Formula/sdkmancli.rb
No available formula with the name "sdkmancli". Did you mean sdkman-cli?
In formula file: /opt/homebrew/Library/Taps/sdkman/homebrew-tap/Formula/sdkmancli.rb
Expected to find class Sdkmancli, but only found: SdkmanCli.
Error: Invalid formula (el_capitan): /opt/homebrew/Library/Taps/sdkman/homebrew-tap/Formula/sdkmancli.rb
No available formula with the name "sdkmancli". Did you mean sdkman-cli?
In formula file: /opt/homebrew/Library/Taps/sdkman/homebrew-tap/Formula/sdkmancli.rb
Expected to find class Sdkmancli, but only found: SdkmanCli.
Error: Invalid formula (x86_64_linux): /opt/homebrew/Library/Taps/sdkman/homebrew-tap/Formula/sdkmancli.rb
No available formula with the name "sdkmancli". Did you mean sdkman-cli?
In formula file: /opt/homebrew/Library/Taps/sdkman/homebrew-tap/Formula/sdkmancli.rb
Expected to find class Sdkmancli, but only found: SdkmanCli.
Error: Cannot tap sdkman/tap: invalid syntax in tap!